### PR TITLE
Gt blog try

### DIFF
--- a/TabloidCLI/UserInterfaceManagers/BackgroundColorManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/BackgroundColorManager.cs
@@ -23,7 +23,7 @@ namespace TabloidCLI.UserInterfaceManagers
 
             for (int i = 0; i < colors.Length; i++)
             {
-                if (colors[0] == currentForeground) continue;
+                if (colors[i] == currentForeground) continue;
 
                 Console.WriteLine($"{i + 1} {colors[i]}");
             }

--- a/TabloidCLI/UserInterfaceManagers/BlogManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/BlogManager.cs
@@ -148,7 +148,20 @@ namespace TabloidCLI.UserInterfaceManagers
             Blog blogToDelete = Choose("Which blog would you like to remove?");
             if (blogToDelete != null)
             {
-                _blogRepository.Delete(blogToDelete.Id);
+                try 
+                {
+                    // Here we try to delete a blog using the Delete method found in BlogRepository.cs
+                    // If there are posts in the database that reference the ID of the  blog we are trying to delete, 
+                    // a `Microsoft.Data.SqlClient.SqlException` error is thrown
+                    _blogRepository.Delete(blogToDelete.Id);
+                }
+                catch (Microsoft.Data.SqlClient.SqlException)
+                {
+                    // If the error would be thrown, the try/catch statement stops the code above from executing
+                    // and instead executes this code
+                    Console.WriteLine("Cannot delete the selected blog while posts exist");
+                }
+                
             }
         }
 

--- a/TabloidCLI/UserInterfaceManagers/PostManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostManager.cs
@@ -285,7 +285,7 @@ namespace TabloidCLI.UserInterfaceManagers
 
             int postToDelete = Int32.Parse(Console.ReadLine());
 
-
+            
             _postRepository.Delete(posts[postToDelete - 1].Id);
         }
     }


### PR DESCRIPTION
## Changes Made:
1. Put a try/catch statement in BlogManager.cs that prevents attempts to remove blogs that are referenced by other database items
2. Fixed a bug in BackgroundColorManager.cs where the current foreground color would display as a background option

## How to Check:
1. Fetch gt-blog-try
2. Attempt to delete a blog that has a post assigned to it; observe that the catch statement works and an exception is not thrown
3. Enter the background color change menu. Observe that the foreground color (should be Gray) does not show up as a background option.